### PR TITLE
Prepare a 1.9.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ use zbus::{dbus_interface, fdo};
 
 struct Greeter {
     count: u64
-};
+}
 
 #[dbus_interface(name = "org.zbus.MyGreeter1")]
 impl Greeter {

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zbus"
-version = "1.9.2"
+version = "1.9.3"
 authors = ["Zeeshan Ali <zeeshanak@gnome.org>"]
 edition = "2018"
 
@@ -21,7 +21,7 @@ nix = "0.22.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_repr = "0.1"
 zvariant = { path = "../zvariant", version = "2", default-features = false, features = ["enumflags2"] }
-zbus_macros = { path = "../zbus_macros", version = "=1.9.2" }
+zbus_macros = { path = "../zbus_macros", version = "=1.9.3" }
 enumflags2 = { version = "0.6.4", features = ["serde"] }
 serde-xml-rs = { version = "0.4.0", optional = true }
 derivative = "2.1"

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -17,7 +17,7 @@ xml = ["serde-xml-rs"]
 
 [dependencies]
 byteorder = "1.3.1"
-nix = "0.20.2"
+nix = "0.22.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_repr = "0.1"
 zvariant = { path = "../zvariant", version = "2", default-features = false, features = ["enumflags2"] }

--- a/zbus/src/address.rs
+++ b/zbus/src/address.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use crate::{Error, Result};
 use async_io::Async;
 use nb_connect::unix;

--- a/zbus/src/error.rs
+++ b/zbus/src/error.rs
@@ -106,9 +106,7 @@ impl From<io::Error> for Error {
 
 impl From<nix::Error> for Error {
     fn from(val: nix::Error) -> Self {
-        val.as_errno()
-            .map(|errno| io::Error::from_raw_os_error(errno as i32).into())
-            .unwrap_or_else(|| io::Error::new(io::ErrorKind::Other, val).into())
+        io::Error::from_raw_os_error(val as i32).into()
     }
 }
 

--- a/zbus/src/lib.rs
+++ b/zbus/src/lib.rs
@@ -73,7 +73,7 @@
 //!
 //! struct Greeter {
 //!     count: u64
-//! };
+//! }
 //!
 //! #[dbus_interface(name = "org.zbus.MyGreeter1")]
 //! impl Greeter {

--- a/zbus/src/raw/socket.rs
+++ b/zbus/src/raw/socket.rs
@@ -85,8 +85,7 @@ impl Socket for UnixStream {
                 }
                 Ok((msg.bytes, fds))
             }
-            Err(nix::Error::Sys(e)) => Err(e.into()),
-            _ => Err(io::Error::new(io::ErrorKind::Other, "unhandled nix error")),
+            Err(e) => Err(e.into()),
         }
     }
 
@@ -104,8 +103,7 @@ impl Socket for UnixStream {
                 "failed to write to buffer",
             )),
             Ok(n) => Ok(n),
-            Err(nix::Error::Sys(e)) => Err(e.into()),
-            _ => Err(io::Error::new(io::ErrorKind::Other, "unhandled nix error")),
+            Err(e) => Err(e.into()),
         }
     }
 

--- a/zbus/src/utils.rs
+++ b/zbus/src/utils.rs
@@ -21,19 +21,13 @@ pub(crate) fn wait_on(fd: RawFd, flags: PollFlags) -> std::io::Result<()> {
     loop {
         match poll(&mut [pollfd], -1) {
             Ok(_) => break,
-            Err(nix::Error::Sys(e)) => {
+            Err(e) => {
                 if e == Errno::EAGAIN || e == Errno::EINTR {
                     // we got interupted, try polling again
                     continue;
                 } else {
                     return Err(std::io::Error::from(e));
                 }
-            }
-            _ => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "unhandled nix error",
-                ))
             }
         }
     }

--- a/zbus_macros/Cargo.toml
+++ b/zbus_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zbus_macros"
 # Keep version in sync with zbus crate
-version = "1.9.2"
+version = "1.9.3"
 authors = ["Marc-André Lureau <marcandre.lureau@redhat.com>"]
 edition = "2018"
 

--- a/zbus_macros/src/lib.rs
+++ b/zbus_macros/src/lib.rs
@@ -59,7 +59,7 @@ mod utils;
 ///
 ///     #[dbus_proxy(signal)]
 ///     fn some_signal(&self, arg1: &str, arg2: u32) -> fdo::Result<()>;
-/// };
+/// }
 ///
 /// let connection = Connection::new_session()?;
 /// let proxy = SomeIfaceProxy::new(&connection)?;

--- a/zbus_macros/tests/ui/proxy/no_zvariant_type_impl.stderr
+++ b/zbus_macros/tests/ui/proxy/no_zvariant_type_impl.stderr
@@ -1,41 +1,72 @@
-warning: use of deprecated function `nb_connect::unix`: This crate is now deprecated in favor of [socket2](https://crates.io/crates/socket2).
- --> $WORKSPACE/zbus/src/address.rs
-  |
-  | use nb_connect::unix;
-  |     ^^^^^^^^^^^^^^^^
-  |
-  = note: `#[warn(deprecated)]` on by default
-
-warning: use of deprecated function `nb_connect::unix`: This crate is now deprecated in favor of [socket2](https://crates.io/crates/socket2).
-  --> $WORKSPACE/zbus/src/address.rs
-   |
-   |                 let stream = unix(p)?;
-   |                              ^^^^
-
-warning: 2 warnings emitted
+error[E0277]: the trait bound `Foo: Type` is not satisfied
+   --> tests/ui/proxy/no_zvariant_type_impl.rs:8:1
+    |
+8   | / #[dbus_proxy(
+9   | |     interface = "org.freedesktop.zbus.Test",
+10  | |     default_service = "org.freedesktop.zbus",
+11  | |     default_path = "/org/freedesktop/zbus/test"
+12  | | )]
+    | |__^ the trait `Type` is not implemented for `Foo`
+    |
+    = help: the following other types implement trait `Type`:
+              &T
+              ()
+              (T0, T1)
+              (T0, T1, T2)
+              (T0, T1, T2, T3)
+              (T0, T1, T2, T3, T4)
+              (T0, T1, T2, T3, T4, T5)
+              (T0, T1, T2, T3, T4, T5, T6)
+            and 84 others
+note: required by a bound in `Proxy::<'a>::call`
+   --> $WORKSPACE/zbus/src/proxy.rs
+    |
+    |         B: serde::ser::Serialize + zvariant::Type,
+    |                                    ^^^^^^^^^^^^^^ required by this bound in `Proxy::<'a>::call`
+    = note: this error originates in the attribute macro `dbus_proxy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Foo: Type` is not satisfied
-  --> tests/ui/proxy/no_zvariant_type_impl.rs:8:1
-   |
-8  | / #[dbus_proxy(
-9  | |     interface = "org.freedesktop.zbus.Test",
-10 | |     default_service = "org.freedesktop.zbus",
-11 | |     default_path = "/org/freedesktop/zbus/test"
-12 | | )]
-   | |__^ the trait `Type` is not implemented for `Foo`
-   |
-   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> tests/ui/proxy/no_zvariant_type_impl.rs:8:1
+    |
+8   | / #[dbus_proxy(
+9   | |     interface = "org.freedesktop.zbus.Test",
+10  | |     default_service = "org.freedesktop.zbus",
+11  | |     default_path = "/org/freedesktop/zbus/test"
+12  | | )]
+    | |__^ the trait `Type` is not implemented for `Foo`
+    |
+    = help: the following other types implement trait `Type`:
+              &T
+              ()
+              (T0, T1)
+              (T0, T1, T2)
+              (T0, T1, T2, T3)
+              (T0, T1, T2, T3, T4)
+              (T0, T1, T2, T3, T4, T5)
+              (T0, T1, T2, T3, T4, T5, T6)
+            and 84 others
+note: required by a bound in `Proxy::<'a>::call`
+   --> $WORKSPACE/zbus/src/proxy.rs
+    |
+    |         R: serde::de::DeserializeOwned + zvariant::Type,
+    |                                          ^^^^^^^^^^^^^^ required by this bound in `Proxy::<'a>::call`
+    = note: this error originates in the attribute macro `dbus_proxy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Foo: From<OwnedValue>` is not satisfied
-  --> tests/ui/proxy/no_zvariant_type_impl.rs:8:1
-   |
-8  | / #[dbus_proxy(
-9  | |     interface = "org.freedesktop.zbus.Test",
-10 | |     default_service = "org.freedesktop.zbus",
-11 | |     default_path = "/org/freedesktop/zbus/test"
-12 | | )]
-   | |__^ the trait `From<OwnedValue>` is not implemented for `Foo`
-   |
-   = note: required because of the requirements on the impl of `Into<Foo>` for `OwnedValue`
-   = note: required because of the requirements on the impl of `TryFrom<OwnedValue>` for `Foo`
-   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> tests/ui/proxy/no_zvariant_type_impl.rs:8:1
+    |
+8   | / #[dbus_proxy(
+9   | |     interface = "org.freedesktop.zbus.Test",
+10  | |     default_service = "org.freedesktop.zbus",
+11  | |     default_path = "/org/freedesktop/zbus/test"
+12  | | )]
+    | |__^ the trait `From<OwnedValue>` is not implemented for `Foo`
+    |
+    = note: required because of the requirements on the impl of `Into<Foo>` for `OwnedValue`
+    = note: required because of the requirements on the impl of `TryFrom<OwnedValue>` for `Foo`
+note: required by a bound in `Proxy::<'a>::get_property`
+   --> $WORKSPACE/zbus/src/proxy.rs
+    |
+    |         T: TryFrom<OwnedValue>,
+    |            ^^^^^^^^^^^^^^^^^^^ required by this bound in `Proxy::<'a>::get_property`
+    = note: this error originates in the attribute macro `dbus_proxy` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zvariant/src/lib.rs
+++ b/zvariant/src/lib.rs
@@ -1085,7 +1085,7 @@ mod tests {
             process_id: Option<u32>,
             group_id: Option<u32>,
             user: String,
-        };
+        }
         let test = Test {
             process_id: Some(42),
             group_id: None,
@@ -1109,7 +1109,7 @@ mod tests {
             group_id: Option<u32>,
             user: String,
             quota: u8,
-        };
+        }
         let decoded: Result<TestMissing> = from_slice(&encoded, ctxt);
         assert_eq!(
             decoded.unwrap_err(),
@@ -1120,7 +1120,7 @@ mod tests {
         struct TestSkipUnknown {
             process_id: Option<u32>,
             group_id: Option<u32>,
-        };
+        }
         let _: TestSkipUnknown = from_slice(&encoded, ctxt).unwrap();
 
         #[derive(SerializeDict, DeserializeDict, TypeDict, PartialEq, Debug)]
@@ -1128,7 +1128,7 @@ mod tests {
         struct TestUnknown {
             process_id: Option<u32>,
             group_id: Option<u32>,
-        };
+        }
         let decoded: Result<TestUnknown> = from_slice(&encoded, ctxt);
         assert_eq!(
             decoded.unwrap_err(),


### PR DESCRIPTION
In order to help downstream users who are still stuck on the 1.x series protect themselves from a security vulnerability in older versions of the nix crate (https://rustsec.org/advisories/RUSTSEC-2021-0119), this new patch release increases the minimum supported version of the nix crate, and contains no other changes. The previous zbus release in the 1.x series, 1.9.2, is already technically safe from the aforementioned vulnerability; however, due to complications regarding dependency specifications in old versions of the nix crate, many downstream users find themselves unable to use 1.9.2 (or worse, find that Cargo has selected a version that contains a vulnerable nix). This is anticipated to be the final release in the zbus 1.x series, unless a similarly severe security vulnerability is encountered. Users are encouraged to upgrade to the zbus 2.x series, none of which have ever been subject to the vulnerability in question.