### PR TITLE
CI,GH: Cache deps on Windows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -95,7 +95,45 @@ jobs:
       TRYBUILD: overwrite # ignore ui tests
     steps:
       - uses: actions/checkout@v3
+
+      - name: Cache Dependencies
+        id: cache-deps
+        uses: actions/cache@v3
+        with:
+          path: |
+            c:/share/*dbus*
+            c:/lib/libexpat.lib
+            c:/bin/libexpat.dll
+            c:/bin/xmlwf.exe
+            c:/bin/*dbus*
+            c:/lib/*dbus*
+            c:/var/lib/*dbus*
+            c:/lib/*glib*
+            c:/lib/*gio*
+            c:/lib/*gobject*
+            c:/lib/*gmodule*
+            c:/lib/*gthread*
+            c:/lib/*gspawn*
+            c:/lib/*gresource*
+            c:/lib/*pcre*
+            c:/lib/*z*
+            c:/lib/*ffi*
+            c:/lib/*intl*
+            c:/bin/*glib*
+            c:/bin/*gio*
+            c:/bin/*gobject*
+            c:/bin/*gmodule*
+            c:/bin/*gthread*
+            c:/bin/*gspawn*
+            c:/bin/*gresource*
+            c:/bin/*pcre*
+            c:/bin/*z*
+            c:/bin/*ffi*
+            c:/bin/*intl*
+          key: ${{ runner.os }}-cache
+
       - name: Install pkg-config
+        if: steps.cache-deps.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
           # This is needed for some reason: https://github.com/dbus2/zbus/actions/runs/4917893488/jobs/8783555606
@@ -103,11 +141,16 @@ jobs:
           choco install -y pkgconfiglite
 
       - name: Install Meson
+        if: steps.cache-deps.outputs.cache-hit != 'true'
         shell: pwsh
         run: pip3 install meson
 
-      - uses: ilammy/msvc-dev-cmd@v1
+      - name: Setup MSVC Environment
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        uses: ilammy/msvc-dev-cmd@v1
+
       - name: Build & Install GLib
+        if: steps.cache-deps.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
           (New-Object System.Net.WebClient).DownloadString('https://wrapdb.mesonbuild.com/v2/pcre_8.37-2/get_patch') >$null
@@ -119,6 +162,7 @@ jobs:
           meson install --no-rebuild -C builddir
 
       - name: Build & Install libexpat
+        if: steps.cache-deps.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
           # Upstream expat doesn't ship devel? let's build it then...
@@ -129,6 +173,7 @@ jobs:
           cmake --install . --config Release
 
       - name: Build & Install dbus daemon
+        if: steps.cache-deps.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
           git clone --depth 1 https://gitlab.freedesktop.org/dbus/dbus.git \dbus

--- a/zvariant/Cargo.toml
+++ b/zvariant/Cargo.toml
@@ -39,7 +39,7 @@ chrono = { version = "0.4.23", features = ["serde"], default-features = false, o
 [dev-dependencies]
 serde_json = "1.0"
 serde_repr = "0.1.9"
-glib = { git = "https://github.com/gtk-rs/glib", rev = "c9ee583cea0" }
+glib = "0.17.9"
 rand = "0.8.5"
 criterion = "0.4"
 

--- a/zvariant/src/lib.rs
+++ b/zvariant/src/lib.rs
@@ -425,8 +425,8 @@ mod tests {
             // Check encoding against GLib
             let bytes = Bytes::from_owned(encoded);
             let gv = Variant::from_bytes::<Variant>(&bytes);
-            let variant = gv.get_variant().unwrap();
-            assert_eq!(variant.get_str().unwrap(), "hello world");
+            let variant = gv.as_variant().unwrap();
+            assert_eq!(variant.str().unwrap(), "hello world");
         }
 
         let v: String = v.try_into().unwrap();
@@ -595,8 +595,8 @@ mod tests {
             let bytes = Bytes::from_owned(gv_encoded);
             let variant = Variant::from_bytes::<&[u8]>(&bytes);
             assert_eq!(variant.n_children(), 2);
-            assert_eq!(variant.get_child_value(0).get::<u8>().unwrap(), 77);
-            assert_eq!(variant.get_child_value(1).get::<u8>().unwrap(), 88);
+            assert_eq!(variant.child_value(0).get::<u8>().unwrap(), 77);
+            assert_eq!(variant.child_value(1).get::<u8>().unwrap(), 88);
         }
         let ctxt = Context::<LE>::new_dbus(0);
 
@@ -729,7 +729,7 @@ mod tests {
             let bytes = Bytes::from_owned(gv_encoded);
             let variant = Variant::from_bytes::<Variant>(&bytes);
             assert_eq!(variant.n_children(), 1);
-            let decoded: Vec<String> = variant.get_child_value(0).get().unwrap();
+            let decoded: Vec<String> = variant.child_value(0).get().unwrap();
             assert_eq!(decoded[0], "Hello");
             assert_eq!(decoded[1], "World");
         }
@@ -803,7 +803,7 @@ mod tests {
             >(&bytes);
             assert_eq!(variant.n_children(), 1);
             let r: (u8, u32, (i64, bool, i64, Vec<String>), String) =
-                variant.get_child_value(0).get().unwrap();
+                variant.child_value(0).get().unwrap();
             assert_eq!(r.0, u8::max_value());
             assert_eq!(r.1, u32::max_value());
         }
@@ -890,9 +890,9 @@ mod tests {
             let bytes = Bytes::from_owned(gv_encoded);
             let variant = Variant::from_bytes::<Variant>(&bytes);
             assert_eq!(variant.n_children(), 1);
-            let child: Variant = variant.get_child_value(0);
+            let child: Variant = variant.child_value(0);
             let r: (u8, u32, (i64, bool, i64, Vec<String>), String) =
-                child.get_child_value(0).get().unwrap();
+                child.child_value(0).get().unwrap();
             assert_eq!(r.0, u8::max_value());
             assert_eq!(r.1, u32::max_value());
 
@@ -920,8 +920,8 @@ mod tests {
             let bytes = Bytes::from_owned(gv_encoded.clone());
             let variant = Variant::from_bytes::<Vec<String>>(&bytes);
             assert_eq!(variant.n_children(), 2);
-            assert_eq!(variant.get_child_value(0).get::<String>().unwrap(), as_[0]);
-            assert_eq!(variant.get_child_value(1).get::<String>().unwrap(), as_[1]);
+            assert_eq!(variant.child_value(0).get::<String>().unwrap(), as_[0]);
+            assert_eq!(variant.child_value(1).get::<String>().unwrap(), as_[1]);
             // Also check if our own deserializer does the right thing
             let as2 = from_slice::<LE, Vec<String>>(&gv_encoded, ctxt).unwrap();
             assert_eq!(as2, as_);
@@ -1593,7 +1593,7 @@ mod tests {
         // Check encoding against GLib
         let bytes = Bytes::from_owned(encoded);
         let variant = Variant::from_bytes::<Variant>(&bytes);
-        let decoded = variant.get_child_value(0).get::<Option<i16>>().unwrap();
+        let decoded = variant.child_value(0).get::<Option<i16>>().unwrap();
         assert_eq!(decoded, mn);
 
         // Now a None of the same type
@@ -1637,7 +1637,7 @@ mod tests {
         // Check encoding against GLib
         let bytes = Bytes::from_owned(encoded);
         let variant = Variant::from_bytes::<Variant>(&bytes);
-        let decoded = variant.get_child_value(0).get::<Option<String>>().unwrap();
+        let decoded = variant.child_value(0).get::<Option<String>>().unwrap();
         assert_eq!(decoded.as_deref(), ms);
 
         // Now a None of the same type
@@ -1678,10 +1678,7 @@ mod tests {
         // Check encoding against GLib
         let bytes = Bytes::from_owned(encoded);
         let variant = Variant::from_bytes::<Variant>(&bytes);
-        let decoded = variant
-            .get_child_value(0)
-            .get::<Vec<Option<String>>>()
-            .unwrap();
+        let decoded = variant.child_value(0).get::<Vec<Option<String>>>().unwrap();
         assert_eq!(decoded, ams);
 
         // In a struct
@@ -1711,7 +1708,7 @@ mod tests {
         let bytes = Bytes::from_owned(encoded);
         let variant = Variant::from_bytes::<Variant>(&bytes);
         let decoded = variant
-            .get_child_value(0)
+            .child_value(0)
             .get::<(Option<String>, u64, Option<String>)>()
             .unwrap();
         assert_eq!(decoded, structure);


### PR DESCRIPTION
Windows is the slowest (takes 15 mins) of the CI jobs. Let's make it faster by caching the built and installed deps.

---

Zeeshan Ali Khan on behalf of MBition GmbH.

[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md#mbition-gmbh).
